### PR TITLE
Shebang portability fix

### DIFF
--- a/cmd/index.js
+++ b/cmd/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-modules
+#!/usr/bin/env -S node --experimental-modules
 
 import path from 'path';
 import resolve from 'resolve';


### PR DESCRIPTION
Add the -S option to `env` to split the parameter on Linux. Without this, the command is executed as `env "node --experimental-modules"`, which results in the following error:

```
env: ‘node --experimental-modules’: No such file or directory
env: use -[v]S to pass options in shebang lines
```

The -S option is available on Linux as of [GNU coreutils 8.30](https://savannah.gnu.org/forum/forum.php?forum_id=9187) (July 2018), and, according to [this](https://apple.stackexchange.com/a/297535), also works with the macOS (BSD) `env`.